### PR TITLE
More static meson

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Reconfigure Meson if meson.* changed, or run manually
         if: github.event_name == 'workflow_dispatch' || contains(join(github.event.commits.*.modified), 'meson.')
-        run: meson setup -Dclient=true -Dserver=true --wipe --buildtype=release --optimization=3 builddir/      
+        run: meson setup -Dclient=true -Dserver=true -Ddefault_library=static -Db_vscrt=static --wipe --buildtype=release --optimization=3 builddir/      
       - name: Configure Project
         run: meson setup -Dclient=true -Dserver=true --buildtype=release --optimization=3 builddir/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Reconfigure Meson if meson.* changed, or run manually
         if: github.event_name == 'workflow_dispatch' || contains(join(github.event.commits.*.modified), 'meson.')
-        run: meson setup -Dclient=true -Dserver=true -Ddefault_library=static -Db_vscrt=static --wipe --buildtype=release --optimization=3 builddir/      
+        run: meson setup -Dclient=true -Dserver=true -Ddefault_library=static -Db_vscrt=mt --wipe --buildtype=release --optimization=3 builddir/      
       - name: Configure Project
         run: meson setup -Dclient=true -Dserver=true --buildtype=release --optimization=3 builddir/
 


### PR DESCRIPTION
meson setup now uses more static linking so installing Visual C++ Redistributables on a fresh windows isn't needed any more, as seen on the tests below.
fixes #20 
<img width="2560" height="1127" alt="Screenshot from 2025-09-21 13-31-47" src="https://github.com/user-attachments/assets/c79f5a32-f340-4b7f-afb4-f656e2930955" />
