### PR TITLE
fix(server): thread safety (now we actually lock things)

### DIFF
--- a/src/server/gameManager.hpp
+++ b/src/server/gameManager.hpp
@@ -24,13 +24,15 @@ class ServerGame {
 // === Global Game Manager ===
 class GameManager {
    private:
-    std::mutex mtx;
+    mutable std::mutex mtx;
 
    public:
     std::unordered_map<std::string, ServerGame> players;
     enum Status : uint8_t { WAITING, IN_PROGRESS } status = WAITING;
 
-    void lock() { std::lock_guard lock(this->mtx); }
+    std::unique_lock<std::mutex> acquire_lock() const {
+        return std::unique_lock<std::mutex>(mtx);
+    }
 
     // static std::string generate_id() {
     //     static std::mt19937 rng(std::random_device{}());
@@ -48,7 +50,7 @@ class GameManager {
     }
 
     std::pair<ServerGame*, bool> join_game(const std::string& name) {
-        this->lock();
+        std::lock_guard<std::mutex> lock(this->mtx);
 
         if (this->already_joined(name)) {
             return {&players[name], true};
@@ -65,7 +67,7 @@ class GameManager {
     }
 
     nlohmann::json get_game_state() {
-        this->lock();
+        std::lock_guard<std::mutex> lock(this->mtx);
         nlohmann::json res;
 
         res["status"] = (status == WAITING) ? "waiting" : "in_progress";

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -26,7 +26,6 @@ void join(const httplib::Request& req, httplib::Response& res) {
     }
 
     std::string uname = req.get_param_value("username");
-    manager.lock();
 
     auto [p, joined_already] = manager.join_game(uname);
     if (joined_already) {
@@ -51,13 +50,13 @@ void bet(const httplib::Request& req, httplib::Response& res) {
         return;
     }
 
-    manager.lock();
     if (!manager.already_joined(uname)) {
         res.status = 400;
         res.set_content("not joined", "text/plain");
         return;
     }
 
+    auto lock = manager.acquire_lock();
     auto& game = manager.players[uname].game;
     auto& player = game.player;
     if (!player.getHand().empty() && !game.hasEnded()) {
@@ -119,7 +118,7 @@ void move(const httplib::Request& req, httplib::Response& res) {
         }
     }
 
-    manager.lock();
+    auto lock = manager.acquire_lock();
     if (!req.has_param("action")) {
         res.status = 400;
         res.set_content("missing action parameter", "text/plain");


### PR DESCRIPTION
this implementation has 2 new ways of thread locking (it could still probably be better but this was all the energy i could spend on this):

- using `GameManager::acquire_lock()` will create a `std::unique_lock()` with the base classes mutex, and since its a unique lock, assigning it to a local variable like: `auto lock = manager.acquire_lock()` will move it into the variable, therefore actually locking (afaik this couldn't be done with a `std::scoped_lock` or `std::lock_guard`)

- using `std::lock_guard` in most of the functions of the manager class, simple and works well

> **Warning:** There might be other places in the codebase that aren't thread safe, this needs further inspection
