### PR TITLE
ci(build): don't go too crazy over efficiency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,15 +52,7 @@ jobs:
           cache-dependency-path: 'build-sys-pip-pkgs.txt'
       - run: pip install -r build-sys-pip-pkgs.txt
 
-      - uses: dorny/paths-filter@v3
-        id: did-change
-        with:
-          filters: |
-            meson:
-              - 'meson.*'
-
-      - name: Reconfigure Meson if meson.* changed, or run manually
-        if: steps.did-change.outputs.meson == 'true'
+      - name: Reconfigure Meson
         run: meson setup -Dclient=true -Dserver=true -Ddefault_library=static -Db_vscrt=mt --wipe --buildtype=release --optimization=3 builddir/
 
       - name: compile


### PR DESCRIPTION
apparently new meson versions don't like build configs generated by older ones

<https://github.com/jarjk/blackjackpp/actions/runs/18713484892/job/53367217340>

I guess it'd fix that, although badly effecting CI run times